### PR TITLE
#88

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -3,17 +3,22 @@
     <div class="media border-bottom">
       <figure class="align-self-start mr-3">
         <% if post.user.avater? %>
-          <%= image_tag post.user.avater.thumb50.url %>
+          <%= image_tag post.user.avater.thumb50.url, :size => '70x70' %>
         <% else %>
-          <%= image_tag"/assets/default.jpg", :size => '100x100' %>
+          <%= image_tag"/assets/default.jpg", :size => '70x70' %>
         <% end %>
         <figcaption>
           <%=link_to(post.user.name, user_path(post.user_id))%>
         </figcaption>
       </figure>
       <div class="media-body", style="word-break: break-all;">
-        <h5 class="mt-0 text-left"><%= link_to(post.content, post_path(post))%></h5>
         <p class="text-left"> 投稿日時：<%= post.created_at.strftime('%Y年%m月%d日') %> </p>
+        <h5 class="mt-0 text-left"><%= link_to(post.content, post_path(post))%></h5>
+        <% if post.picture? %>
+          <% post.picture.each do |picture| %>
+            <li><%= image_tag picture.thumb.url, :size => '70x70' %></li>
+          <% end %>
+        <% end %>
       </div><!-- /.media-body -->
     </div><!-- /.media -->
   <% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -23,10 +23,10 @@
             <div>
               <%= f.submit "更新する", class: "btn btn-primary" %>
             </div>
-          <ul class="float-left">
+          <ul class="media-picture float-left">
             <% if @post.picture? %>
               <% @post.picture.each do |picture| %>
-                <li><%= image_tag picture.thumb_big.url %></li>
+                <%= image_tag picture.thumb_big.url %>
               <% end %>
             <% end %>
           </ul>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -32,18 +32,18 @@
       </div><!-- /.media -->
       <div class="media border-bottom">
         <div class="media-body", style="word-break: break-all;">
-          <p class="text-left"> 投稿日時：<%= @post.created_at.strftime('%Y年%m月%d日') %> </p>
-          <h5 class="mt-0 text-left"><%= @post.content %></h5>
-          <ul class="float-left">
-            <% if @post.picture? %>
-              <% @post.picture.each do |picture| %>
-                <li><%= image_tag picture.thumb_big.url %></li>
-              <% end %>
-            <% end %>
-          </ul>
           <div class="float-right">
             <%= render "likes/like_button", post: @post %>
           </div>
+          <p class="text-left"> 投稿日時：<%= @post.created_at.strftime('%Y年%m月%d日') %> </p>
+          <h5 class="mt-0 text-left"><%= @post.content %></h5>
+          <ul class="media-picture float-left">
+            <% if @post.picture? %>
+              <% @post.picture.each do |picture| %>
+                <%= image_tag picture.thumb_big.url %>
+              <% end %>
+            <% end %>
+          </ul>
         </div><!-- /.media-body -->
       </div><!-- /.media -->
       <% if current_user.admin? && !(current_user == @admin) %>
@@ -53,7 +53,7 @@
       <% end %>
       <% if @post.user == current_user %>
         <div>
-          <%=link_to "編集",edit_post_path, class: 'btn btn-primary'%>
+          <%=link_to "編集",edit_post_path, class: 'btn btn-success'%>
           <%=link_to "削除",@post,method: :delete,data:{confirm:'本当に削除してよろしいですか？' }, class: 'btn btn-danger' %>
         </div>
       <% end %>  

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -2,7 +2,7 @@
   <div class="media border-bottom">
     <figure class="align-self-start mr-3">
       <% if user.avater? %>
-        <%= image_tag user.avater.thumb50.url %>
+        <%= image_tag user.avater.thumb50.url, :size => '100x100' %>
       <% else %>
         <%= image_tag"/assets/default.jpg", :size => '100x100' %>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,9 @@
 <div class="container userPage" id="wrapper">
   <div class="row">
     <aside class="col-md-3">
-      <div class="profile-avatar border">
+      <div class="profile-avatar">
         <% if @user.avater? %>
-          <%= image_tag @user.avater.thumb.url %>
+          <%= image_tag @user.avater.thumb.url, :size => '200x200' %>
         <% else %>
           <%= image_tag"/assets/default.jpg", :size => '200x200' %>
         <% end %>


### PR DESCRIPTION
投稿一覧表示のレイアウトを修正しました。
投稿した画像を一覧でもみれます。
また、投稿詳細ページの画像表示方法を変えました。サイズが違う画像が複数あってもガタガタになってしまわないようにしています。

また、ユーザのアバター画像の表示も変えました。size設定を加えたことにより、様々な画像も正方形の形になります。

あと、記事の編集ボタンの色も変えています。